### PR TITLE
Replace styled-components import with babel macro import for better DX

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -107,7 +107,7 @@ function App() {
       }
       fetchProtests();
     }
-  }, [state.userCoordinates, state.mapPosition, state.mapPositionHistory, state.loading, state.markers]);
+  }, [state.userCoordinates, state.mapPosition]);
 
   return (
     <AppWrapper>

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import { Admin, GroupUpdate } from './views';
 import ProjectSupportPage from './views/ProjectSupportPage';
 import getDistance from 'geolib/es/getDistance';
 import { pointWithinRadius, validateLatLng } from './utils';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import firebase, { firestore } from './firebase';
 import * as geofirestore from 'geofirestore';
 
@@ -107,7 +107,7 @@ function App() {
       }
       fetchProtests();
     }
-  }, [state.userCoordinates, state.mapPosition]);
+  }, [state.userCoordinates, state.mapPosition, state.mapPositionHistory, state.loading, state.markers]);
 
   return (
     <AppWrapper>

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export default function Button(props) {
   const { color, type, onClick, disabled, style, icon, children } = props;

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 function Footer() {
   return (

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Map, Circle, TileLayer, Marker, Popup } from 'react-leaflet';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import L from 'leaflet';
 
 const protestPoint = ({ iconUrl, iconRetinaUrl, iconSize, iconAnchor }) =>

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import ReactModal from 'react-modal';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import Button from '../Button';
 import { getCurrentPosition } from '../../utils';
 import PlacesAutocomplete from '../PlacesAutocomplete';
@@ -24,7 +24,7 @@ function Modal({ isOpen, setIsOpen, coordinates, setCoordinates }) {
     if (coordinates.length === 2) {
       setIsOpen(false);
     }
-  }, [coordinates]);
+  }, [coordinates, setIsOpen]);
 
   return (
     <ModalWrapper isOpen={isOpen}>

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -24,7 +24,7 @@ function Modal({ isOpen, setIsOpen, coordinates, setCoordinates }) {
     if (coordinates.length === 2) {
       setIsOpen(false);
     }
-  }, [coordinates, setIsOpen]);
+  }, [coordinates]);
 
   return (
     <ModalWrapper isOpen={isOpen}>

--- a/src/components/PlacesAutocomplete/PlacesAutocomplete.js
+++ b/src/components/PlacesAutocomplete/PlacesAutocomplete.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import usePlacesAutocomplete, { getGeocode, getLatLng } from 'use-places-autocomplete';
 import { Combobox, ComboboxInput, ComboboxPopover, ComboboxList, ComboboxOption } from '@reach/combobox';
 

--- a/src/components/ProtestCard/ProtestCard.js
+++ b/src/components/ProtestCard/ProtestCard.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 function formatDistance(distance) {
   if (distance > 1000) {

--- a/src/components/ProtestForm/ProtestForm.js
+++ b/src/components/ProtestForm/ProtestForm.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { Link } from 'react-router-dom';
 // import { ReCaptcha, loadReCaptcha } from 'react-recaptcha-v3';
 import PlacesAutocomplete from '../PlacesAutocomplete';
@@ -60,7 +60,7 @@ function ProtestForm({ initialCoords }) {
       setNearbyProtests(protests);
     }
     nearbyProtests();
-  }, [streetName]);
+  }, [coordinates, streetName]);
 
   const onSubmit = async (params) => {
     if (!streetName) {

--- a/src/components/ProtestForm/ProtestForm.js
+++ b/src/components/ProtestForm/ProtestForm.js
@@ -60,7 +60,7 @@ function ProtestForm({ initialCoords }) {
       setNearbyProtests(protests);
     }
     nearbyProtests();
-  }, [coordinates, streetName]);
+  }, [streetName]);
 
   const onSubmit = async (params) => {
     if (!streetName) {

--- a/src/components/ProtestList/ProtestList.js
+++ b/src/components/ProtestList/ProtestList.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import ProtestCard from '../ProtestCard';
 
 function ProtestListItems({ protests, listTitle }) {

--- a/src/views/Admin.js
+++ b/src/views/Admin.js
@@ -8,7 +8,7 @@ import React, { useEffect, useState } from 'react';
 import { Button } from '../components';
 import { useAuth } from '../hooks';
 import firebase, { firestore, signInWithGoogle } from '../firebase';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { Map, TileLayer, Marker } from 'react-leaflet';
 import * as geofirestore from 'geofirestore';
 import { PlacesAutocomplete } from '../components';

--- a/src/views/GroupUpdate.js
+++ b/src/views/GroupUpdate.js
@@ -8,7 +8,7 @@ import React, { useEffect, useState } from 'react';
 import { Button } from '../components';
 import { useAuth } from '../hooks';
 import firebase, { firestore, signInWithGoogle } from '../firebase';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import API from '../api';
 
 async function getProtestByDisplayName(displayName) {

--- a/src/views/ProjectSupportPage/index.js
+++ b/src/views/ProjectSupportPage/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 function ProjectSupportPage() {
   useEffect(() => {


### PR DESCRIPTION
This PR replaces the styled-components import with an import from styled-components/macro. This allows seeing component names in dev tool, thus making it easier to find them in the code
![image](https://user-images.githubusercontent.com/2545447/95042615-27ccad00-06e3-11eb-988b-c2ba2225fc05.png)
