### PR TITLE
Fix bug with blank page when redirected to the `leader-request` page from sign-up

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -84,13 +84,19 @@ function App() {
   useEffect(() => {
     firebase.auth().onAuthStateChanged(function (user) {
       if (user) {
-       const { uid, displayName, email } = user;
-        // This is the minimal user interface that we need
-        dispatch({ type: 'setUser', payload: { uid, displayName, email } });
         // This adds the "admin" data which is in our DB
         getFullUserData(user.uid).then((fullUserData) => {
-          dispatch({ type: 'setUser', payload: fullUserData });
+          if (fullUserData) {
+            dispatch({ type: 'setUser', payload: fullUserData });
+          } else {
+            const { uid, email } = user;
+            const partialUserData = { uid, email };
+            // When the user is initially created, this request returns undefined
+            // This is a workaround in order to get the uid in the leader reqest page
+            dispatch({ type: 'setUser', payload: partialUserData });
+          }
         });
+        
       } else {
         dispatch({ type: 'setUser', payload: 'visitor' });
       }

--- a/src/App.js
+++ b/src/App.js
@@ -84,7 +84,10 @@ function App() {
   useEffect(() => {
     firebase.auth().onAuthStateChanged(function (user) {
       if (user) {
-        // Includes admin data and more
+       const { uid, displayName, email } = user;
+        // This is the minimal user interface that we need
+        dispatch({ type: 'setUser', payload: { uid, displayName, email } });
+        // This adds the "admin" data which is in our DB
         getFullUserData(user.uid).then((fullUserData) => {
           dispatch({ type: 'setUser', payload: fullUserData });
         });

--- a/src/App.js
+++ b/src/App.js
@@ -93,6 +93,7 @@ function App() {
             const partialUserData = { uid, email };
             // When the user is initially created, this request returns undefined
             // This is a workaround in order to get the uid in the leader reqest page
+            // https://github.com/guytepper/1km.co.il/pull/114
             dispatch({ type: 'setUser', payload: partialUserData });
           }
         });


### PR DESCRIPTION
At the moment there is a weird bug that occurs when there is user is initially signed up and straight away redirected to the `request-leader` page.

The problem is that when trying to receive the user data it returns as `undefined`. It happens because it's not yet updated in the DB and the user sees a blank page.

In order to recreate that scenario, I needed to completely remove my user from firebase and do this flow from the beginning .The solution that presented here is a workaround, but should work for now and help for the case when a user was just created. It should be ok, because the additional data (whether the user is an `admin` or not, is not relevant at this point).

TypeScript could definitely help here, we would write the interfaces for the partial and the full user.