### PR TITLE
Added vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
Disable GitHub comments by Vercel. 
You can still view the deployed version above the comment form.

<img width="550" alt="Screen Shot 2020-10-11 at 15 44 59" src="https://user-images.githubusercontent.com/13344923/95679085-3e8a6c80-0bd9-11eb-981d-13630cd2dbd8.png">