### PR TITLE
Fixed URL validation method

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -78,12 +78,15 @@ export function getUpcomingDate(dateTimeList) {
   return sortDateTimeList(dateTimeList).filter((dateTimeList) => new Date(dateTimeList.date) >= new Date())[0];
 }
 
-export function isValidUrl(url) {
+export function isValidUrl(link) {
+  let url;
+
   try {
-    new URL(url);
+    url = new URL(link);
   } catch (e) {
     return false;
   }
+
   return url.protocol === 'http:' || url.protocol === 'https:';
 }
 


### PR DESCRIPTION
The error, which was introduced in #86, was that the author seemed to forget to add the `url` variable :)