### PR TITLE
Support for protest march polylines

### DIFF
--- a/src/stores/ProtestStore.js
+++ b/src/stores/ProtestStore.js
@@ -13,8 +13,18 @@ class ProtestStore {
 
   get closeProtests() {
     if (this.nearbyProtests.length > 0) {
-      return this.nearbyProtests.filter((p) => p.distance < 2000).sort((p1, p2) => p1.distance - p2.distance);
+      const closeList = this.nearbyProtests.filter((p) => p.distance < 2000).sort((p1, p2) => p1.distance - p2.distance);
+
+      // Temporary code for Ramart Gan - Givayayim march.
+      const marchProtest = this.nearbyProtests.find((p) => p.id === 'eoLv9Kb4x3sFBcAkcdMh');
+      console.log(marchProtest.id);
+      if (marchProtest) {
+        closeList.splice(closeList.indexOf(marchProtest), 1);
+        closeList.unshift(marchProtest);
+      }
+      return closeList;
     }
+
     return [];
   }
 

--- a/src/stores/ProtestStore.js
+++ b/src/stores/ProtestStore.js
@@ -14,15 +14,18 @@ class ProtestStore {
   get closeProtests() {
     if (this.nearbyProtests.length > 0) {
       const closeList = this.nearbyProtests.filter((p) => p.distance < 2000).sort((p1, p2) => p1.distance - p2.distance);
-
-      // Temporary code for Ramart Gan - Givayayim march.
-      const marchProtest = this.nearbyProtests.find((p) => p.id === 'eoLv9Kb4x3sFBcAkcdMh');
-      console.log(marchProtest.id);
-      if (marchProtest) {
-        closeList.splice(closeList.indexOf(marchProtest), 1);
-        closeList.unshift(marchProtest);
-      }
       return closeList;
+
+      // Use in times when need to push a protest up in the list
+      // For example, during marches, we want the protest to be the first available even if
+      // the protest location is not the closest to the user.
+
+      // const marchProtest = this.nearbyProtests.find((p) => p.id === 'eoLv9Kb4x3sFBcAkcdMh');
+      // if (marchProtest) {
+      //   closeList.splice(closeList.indexOf(marchProtest), 1);
+      //   closeList.unshift(marchProtest);
+      // }
+      // return closeList;
     }
 
     return [];

--- a/src/views/ProtestPage.js
+++ b/src/views/ProtestPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useStore } from '../stores';
 import styled from 'styled-components/macro';
@@ -11,7 +11,7 @@ import {
   updateProtest,
   getLatestProtestPictures,
 } from '../api';
-import { Map, Marker, TileLayer } from 'react-leaflet';
+import { Map, Marker, Polyline, TileLayer } from 'react-leaflet';
 import { ProtectedRoute, ProtestForm, PictureGallery } from '../components';
 import {
   ProtestCardDetail,
@@ -84,6 +84,9 @@ function getFutureDates(dateTimeList) {
 
 function ProtestPageContent({ protest, user, userCoordinates }) {
   const history = useHistory();
+  const mapElement = useRef(null);
+  const polylineElement = useRef(null);
+  const [polyPositions, setPolyPositions] = useState([]);
   const { coordinates, displayName, streetAddress, notes, dateTimeList } = protest;
   const [latestPictures, setLatestPictures] = useState([]);
   const galleryMatch = useRouteMatch('/protest/:id/gallery');
@@ -98,16 +101,40 @@ function ProtestPageContent({ protest, user, userCoordinates }) {
     getLatestPictures();
   }, [protest]);
 
+  useEffect(() => {
+    if (protest.positions?.length > 0) {
+      const polyPositions = protest.positions.map((p) => [p.latlng.latitude, p.latlng.longitude]);
+      setPolyPositions(polyPositions);
+    }
+  }, [protest]);
+
+  useEffect(() => {
+    if (polyPositions.length > 0 && polylineElement.current) {
+      const polyBounds = polylineElement.current.leafletElement.getBounds();
+      mapElement.current.leafletElement.flyToBounds(polyBounds);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [polyPositions]);
+
   const futureDates = getFutureDates(dateTimeList);
 
   return (
     <ProtestPageContainer>
-      <MapWrapper center={{ lat: coordinates.latitude, lng: coordinates.longitude }} zoom={14}>
+      <MapWrapper center={{ lat: coordinates.latitude, lng: coordinates.longitude }} zoom={14} ref={mapElement}>
         <TileLayer
           attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <Marker position={{ lat: coordinates.latitude, lng: coordinates.longitude }}></Marker>
+        {polyPositions.length > 0 && (
+          <>
+            <Polyline ref={polylineElement} positions={polyPositions} />
+            {polyPositions.map((position) => (
+              <Marker position={{ lat: position[0], lng: position[1] }} key={position[0]}></Marker>
+            ))}
+          </>
+        )}
       </MapWrapper>
 
       <ProtestContainer>


### PR DESCRIPTION
Display a polyline in the protest page map if the protest has the `positions` field in it.

Also added an option to shift the protest position in the selection list to be the 1st one (useful for marches). 
Currently it's commented out in the `ProtestStore`, waiting to be activated when needed.

![Screen Shot 2020-11-06 at 11 51 29](https://user-images.githubusercontent.com/13344923/98352238-69c07a00-2026-11eb-980e-d973f85a3706.png)
