### PR TITLE
#195 Style AddressBar's focus ring on Android 

### DIFF
--- a/src/components/Map/AddressBar/AddressBar.js
+++ b/src/components/Map/AddressBar/AddressBar.js
@@ -109,7 +109,7 @@ const ComboboxInputWrapper = styled(ComboboxInput)`
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 2px #b8c0fc;
+    box-shadow: 0 0 0 3px #b8c0fc;
   }
 
   @media (min-width: 768px) {

--- a/src/components/Map/AddressBar/AddressBar.js
+++ b/src/components/Map/AddressBar/AddressBar.js
@@ -107,6 +107,11 @@ const ComboboxInputWrapper = styled(ComboboxInput)`
   box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.2);
   z-index: 10000;
 
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px #b8c0fc;
+  }
+
   @media (min-width: 768px) {
     right: 10%;
     width: 50%;


### PR DESCRIPTION
So I decided to go with `#b8c0fc`.
To deal with the problem I've set the outline on focus to none and used box-shadow instead.
Result:
Chrome on pc:
![image](https://user-images.githubusercontent.com/54754198/98532604-98d72580-228a-11eb-9bd6-f51c0044169b.png)

Chome on my android:
![image](https://user-images.githubusercontent.com/54754198/98532738-c45a1000-228a-11eb-8ba6-9180fadb492e.png)

This how  is `#7785fc` looks like if you prefer:
![image](https://user-images.githubusercontent.com/54754198/98533055-24e94d00-228b-11eb-85be-bb757efdc9f0.png)
